### PR TITLE
add a missing   Wizard.CloseDialog (bsc#1194279)

### DIFF
--- a/src/clients/inst_cc_mode.rb
+++ b/src/clients/inst_cc_mode.rb
@@ -106,6 +106,7 @@ module Yast
         WFM.Write(path(".local.string"), "/etc/gcrypt/fips_enabled", "1")
       end
 
+      Wizard.CloseDialog
       ret
     end
   end


### PR DESCRIPTION
## Problem

Wizard layout problem when going back ... as the wizard is not closed.

- https://bugzilla.suse.com/show_bug.cgi?id=1194279
- *openQA link*



## Solution

Added missing Wizard.CloseDialog as suggested.


## Testing

- untested



## Screenshots

*If the fix affects the UI attach some screenshots here.*

