### PR TITLE
Restore UI layout after Common Criteria confirmation (bsc#1194279) 

### DIFF
--- a/package/system-role-common-criteria.changes
+++ b/package/system-role-common-criteria.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May  9 08:42:36 UTC 2022 - Marcus Meissner <meissner@suse.com>
+
+- Restore UI layout after Common Criteria confirmation (bsc#1194279)
+- 15.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 15.4.0 (bsc#1185510)

--- a/package/system-role-common-criteria.spec
+++ b/package/system-role-common-criteria.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-installation-control >= 4.0.4
 
 Url:            https://github.com/yast/system-role-common-criteria
 AutoReqProv:    off
-Version:        15.4.0
+Version:        15.4.1
 Release:        0
 Summary:        System role for Common Criteria Certification
 License:        MIT

--- a/src/clients/inst_cc_mode.rb
+++ b/src/clients/inst_cc_mode.rb
@@ -106,6 +106,7 @@ module Yast
         WFM.Write(path(".local.string"), "/etc/gcrypt/fips_enabled", "1")
       end
 
+      Wizard.CloseDialog
       ret
     end
   end


### PR DESCRIPTION
## Problem

Selecting the "Common Criteria evaluated configuration" System Role    produces a confirmation screen with a different, wider, layout. A missing    `CloseDialog` means this layout would persist after that confirmation is made.

- [bsc#1194279](https://bugzilla.suse.com/show_bug.cgi?id=1194279)
- retargetting #7 onto SP4

## Solution

```diff
+ Wizard.CloseDialog
```

## Testing

Tested manually: 
- SLE-15-SP4-Online-x86_64-Build148.1-Media1.iso , with `... dud=/system-role-common-criteria.rpm`
- Select SLES product, ...
- Register, ...
- Select *Common Criteria* system role

The screen layout works correctly with the fix

## Screenshots

See the bug report, [bsc#1194279](https://bugzilla.suse.com/show_bug.cgi?id=1194279), for screenshots