### PR TITLE
Set the encryption password from the role

### DIFF
--- a/package/system-role-common-criteria.changes
+++ b/package/system-role-common-criteria.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 29 11:39:21 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Set the encryption password directly from the role dialog
+  (jsc#PED-4166, jsc#PED-4474)
+- 15.4.2
+
+-------------------------------------------------------------------
 Mon May  9 08:42:36 UTC 2022 - Marcus Meissner <meissner@suse.com>
 
 - Restore UI layout after Common Criteria confirmation (bsc#1194279)

--- a/package/system-role-common-criteria.spec
+++ b/package/system-role-common-criteria.spec
@@ -73,6 +73,8 @@ mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 install -m 644 LICENSE $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 mkdir -p %{buildroot}/%{_datadir}/YaST2/lib/y2system_role_handlers
 install -m 644 src/lib/y2system_role_handlers/cc_role_finish.rb %{buildroot}/%{_datadir}/YaST2/lib/y2system_role_handlers
+mkdir -p %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria/dialogs
+install -m 644 src/lib/y2common_criteria/dialogs/installation.rb %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria/dialogs/installation.rb
 mkdir -p %{buildroot}/%{_datadir}/YaST2/clients
 install -m 644 src/clients/inst_cc_mode.rb %{buildroot}/%{_datadir}/YaST2/clients/inst_cc_mode.rb
 

--- a/package/system-role-common-criteria.spec
+++ b/package/system-role-common-criteria.spec
@@ -74,6 +74,8 @@ install -m 644 LICENSE $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 mkdir -p %{buildroot}/%{_datadir}/YaST2/lib/y2system_role_handlers
 install -m 644 src/lib/y2system_role_handlers/cc_role_finish.rb %{buildroot}/%{_datadir}/YaST2/lib/y2system_role_handlers
 mkdir -p %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria/dialogs
+install -m 644 src/lib/y2common_criteria.rb %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria.rb
+install -m 644 src/lib/y2common_criteria/encryption.rb %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria/encryption.rb
 install -m 644 src/lib/y2common_criteria/dialogs/installation.rb %{buildroot}/%{_datadir}/YaST2/lib/y2common_criteria/dialogs/installation.rb
 mkdir -p %{buildroot}/%{_datadir}/YaST2/clients
 install -m 644 src/clients/inst_cc_mode.rb %{buildroot}/%{_datadir}/YaST2/clients/inst_cc_mode.rb

--- a/package/system-role-common-criteria.spec
+++ b/package/system-role-common-criteria.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-installation-control >= 4.0.4
 
 Url:            https://github.com/yast/system-role-common-criteria
 AutoReqProv:    off
-Version:        15.4.1
+Version:        15.4.2
 Release:        0
 Summary:        System role for Common Criteria Certification
 License:        MIT

--- a/src/clients/inst_cc_mode.rb
+++ b/src/clients/inst_cc_mode.rb
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) [2020-2023] SUSE LLC
 #
 #
 # This program is free software; you can redistribute it and/or modify it under
@@ -17,99 +17,6 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
-module Yast
-  class CCModuleClient < Client
-    include Yast::I18n
-    
-    def initialize
-      textdomain "cc"
+require "y2common_criteria/dialogs/installation"
 
-      Yast.import "UI"
-      Yast.import "Wizard"
-      Yast.import "Directory"
-      Yast.import "GetInstArgs"
-      Yast.import "RichText"
-      Yast.import "CustomDialogs"
-      Yast.import "Language"
-
-    end
-
-    def main
-
-      Wizard.CreateDialog
-
-      display = UI.GetDisplayInfo
-      space = display["TextMode"] ? 1 : 3
-
-      # dialog caption
-      caption = _("SUSE Linux Enterprise Common Criteria Evaluated Configuration")
-
-      text = _("<p><b>Common Criteria Evaluated Configuration enabled</b></p>") +
-        _(
-          "<p>When installing SUSE Linux Enterprise in the Common Criteria evaluated configation," \
-          "some restrictions apply to available configuration options.\n" \
-          "Please refer to the deployment guide before proceeding.\n" \
-          "Click <b>Next</b> to continue. </p>\n\n"
-        )
-
-      # help ttext
-      help = _(
-        "<p>Click <b>Next</b> to continue.</p>\n"
-      )
-
-      if Builtins.regexpmatch(text, "</.*>")
-        rt = RichText(Id(:text), text)
-      else
-        Builtins.y2debug("plain text")
-        rt = RichText(Id(:text), Opt(:plainText), text)
-      end
-
-      contents = VBox(
-        VSpacing(space),
-        HBox(
-          HSpacing(2 * space),
-          rt,
-          HSpacing(2 * space)
-        ),
-        VSpacing(2)
-      )
-
-      entropy = SCR.Read(path(".target.string"), "/proc/sys/kernel/random/entropy_avail").to_s
-      y2milestone("entropy %1", entropy)
-
-      Wizard.SetContents(
-        caption,
-        contents,
-        help,
-        GetInstArgs.enable_back,
-        GetInstArgs.enable_next
-      )
-      Wizard.SetFocusToNextButton
-
-      ret = nil
-      loop do
-        ret = UI.UserInput
-
-        break if ret != :abort
-        break if Popup.ReallyAbort(:painless)
-      end
-
-      if ret == :next
-        # for testing to speed things up
-        #Yast::Pkg.SetSolverFlags("onlyRequires" => true)
-
-        # put libgcrypt into FIPS mode. libstorage-ng calls the cryptsetup
-        # external command so this takes effect when formatting luks volumes.
-        # Needs to happen in instsys. The target system boots with fips=1 kernel
-        # command line so this setting is not needed.
-        WFM.Execute(path(".local.mkdir"), "/etc/gcrypt")
-        WFM.Write(path(".local.string"), "/etc/gcrypt/fips_enabled", "1")
-      end
-
-      Wizard.CloseDialog
-      ret
-    end
-  end
-end
-
-Yast::CCModuleClient.new.main
+Y2CommonCriteria::Dialogs::Installation.new.run

--- a/src/lib/y2common_criteria.rb
+++ b/src/lib/y2common_criteria.rb
@@ -1,0 +1,25 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# Namespace for code specific to the Common Criteria system role
+module Y2CommonCriteria
+end
+
+require "y2common_criteria/encryption"
+require "y2common_criteria/dialogs/installation"

--- a/src/lib/y2common_criteria/dialogs/installation.rb
+++ b/src/lib/y2common_criteria/dialogs/installation.rb
@@ -55,7 +55,7 @@ module Y2CommonCriteria
         HSquash(
           VSquash(
             VBox(
-              MinWidth(60, MinHeight(9, RichText(description_text))),
+              MinWidth(60, MinHeight(10, RichText(description_text))),
               VSpacing(2),
               passwd_widget(:passphrase, _("Encryption Passphrase")),
               passwd_widget(:repeat_passphrase, _("Verify Passphrase")),
@@ -66,7 +66,17 @@ module Y2CommonCriteria
 
       # @return [String]
       def help_text
-        _("<p>Click <b>Next</b> to continue.</p>\n")
+        _(
+          "<p>When installing SUSE Linux Enterprise in the Common Criteria evaluated " \
+          "configuration, some restrictions apply to available configuration options.</p>\n" \
+          "<p>Please refer to the deployment guide before proceeding.</p>\n" \
+          "<p>Common Criteria demands all file systems to be encrypted. The passphrase " \
+          "entered here will be used by default for encrypting devices in the partitioning " \
+          "Guided Setup. That includes the initial partitioning proposal automatically " \
+          "calculated by the installer.</p>\n" \
+          "<p>Notice that you will have to enter the correct password each time you boot " \
+          "the system. So make sure to not lose it!</p>"
+        )
       end
 
       # Handler for the 'next' event (button)
@@ -95,10 +105,11 @@ module Y2CommonCriteria
       # @return [String]
       def description_text
         _(
-          "<p>When installing SUSE Linux Enterprise in the Common Criteria evaluated " \
-          "configuration, some restrictions apply to available configuration options.</p>\n" \
-          "<p>Please refer to the deployment guide before proceeding.</p>\n" \
-          "<p>This is a paragraph about the encryption passphrase.</p>\n"
+          "<p>Please refer to the deployment guide before proceeding with the " \
+          "installation of this Common Criteria evaluated configuration.</p>\n" \
+          "<p>Enter a passphrase below to be used by default when encrypting devices " \
+          "during system installation.</p>\n" \
+          "<p>Read Help for more details.</p>\n"
         )
       end
 

--- a/src/lib/y2common_criteria/dialogs/installation.rb
+++ b/src/lib/y2common_criteria/dialogs/installation.rb
@@ -1,0 +1,99 @@
+# Copyright (c) [2020-2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "ui/installation_dialog"
+
+# Namespace for code specific to the Common Criteria system role
+module Y2CommonCriteria
+  # Dialogs for the Common Criteria role
+  module Dialogs
+    # Main dialog for the Common Criteria system role, to be presented right after the role
+    # selection
+    class Installation < ::UI::InstallationDialog
+      # Constructor
+      def initialize
+        super
+        textdomain "cc"
+        Yast.import "UI"
+        Yast.import "RichText"
+      end
+
+      # @return [String]
+      def dialog_title
+        _("SUSE Linux Enterprise Common Criteria Evaluated Configuration")
+      end
+
+      # @return [Yast::Term] ui content for dialog
+      def dialog_content
+        entropy = Yast::SCR.Read(
+          Yast::Path.new(".target.string"), "/proc/sys/kernel/random/entropy_avail"
+        ).to_s
+        log.info("entropy #{entropy}")
+
+        display = Yast::UI.GetDisplayInfo
+        space = display["TextMode"] ? 1 : 3
+
+        text = _("<p><b>Common Criteria Evaluated Configuration enabled</b></p>") +
+          _(
+            "<p>When installing SUSE Linux Enterprise in the Common Criteria evaluated configation," \
+            "some restrictions apply to available configuration options.\n" \
+            "Please refer to the deployment guide before proceeding.\n" \
+            "Click <b>Next</b> to continue. </p>\n\n"
+          )
+        rt =
+          if Yast::Builtins.regexpmatch(text, "</.*>")
+            RichText(Id(:text), text)
+          else
+            log.debug "plain text"
+            RichText(Id(:text), Opt(:plainText), text)
+          end
+
+        VBox(
+          VSpacing(space),
+          HBox(
+            HSpacing(2 * space),
+            rt,
+            HSpacing(2 * space)
+          ),
+          VSpacing(2)
+        )
+      end
+
+      # @return [String]
+      def help_text
+        _("<p>Click <b>Next</b> to continue.</p>\n")
+      end
+
+      # Handler for the 'next' event (button)
+      def next_handler
+        # for testing to speed things up
+        #Yast::Pkg.SetSolverFlags("onlyRequires" => true)
+
+        # put libgcrypt into FIPS mode. libstorage-ng calls the cryptsetup
+        # external command so this takes effect when formatting luks volumes.
+        # Needs to happen in instsys. The target system boots with fips=1 kernel
+        # command line so this setting is not needed.
+        Yast::WFM.Execute(Yast::Path.new(".local.mkdir"), "/etc/gcrypt")
+        Yast::WFM.Write(Yast::Path.new(".local.string"), "/etc/gcrypt/fips_enabled", "1")
+        super
+      end
+    end
+  end
+end

--- a/src/lib/y2common_criteria/encryption.rb
+++ b/src/lib/y2common_criteria/encryption.rb
@@ -1,0 +1,36 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/secret_attributes"
+
+module Y2CommonCriteria
+  # Auxiliary class to inject the encryption configuration into the ProductFeatures
+  # in a secure way
+  class Encryption
+    include Y2Storage::SecretAttributes
+
+    # Encryption password
+    secret_attr :password
+
+    # Constructor
+    def initialize(passwd)
+      self.password = passwd
+    end
+  end
+end


### PR DESCRIPTION
## Problem

This role already does many things to ensure the resulting system is compliant with Common Criteria.

- It configures libgcrypt for the installation process
- It ensure all the packages needed to tweak the system are installed
- It prevents the storage proposal to create a `/tmp` subvolume by default
- It contains a finish client to execute all the needed scripts to tweak the system

But there is still something it does not do: ensuring all the file-systems of the target system are encrypted with a reasonable passphrase.

Instead of requesting or suggesting such a passphrase, the role just displays this informative dialog and expects the user to remember to use encryption.

![cc](https://github.com/yast/system-role-common-criteria/assets/3638289/3d6011cd-a894-4554-b0f1-41ccf51e5bf5)

We want to take the role one step further and make sure it also facilitates setting encryption. But we want that for already released distributions like 15.4 and 15.5, so we need to implement something that is not intrusive and that does not affect any other scenario or use-case (eg. we cannot modify the user interface of the storage screens like the Guided Setup or the Expert Partitioner).

## Solution

This modifies the dialog in several ways:

- Use the same layout than the rest of the installer.
- Ask for the encryption passphrase, ensuring it's at least 8 characters long and warning the user if it's a weak password.
- Inform the user about the usage of the entered passphrase
- Sets the passphrase as the default `encryption_password` for the storage proposal, so the Guided Setup uses encryption by default (including the initial partitioning proposal automatically done by the installer).

![cc_new1](https://github.com/yast/system-role-common-criteria/assets/3638289/c559eeca-3816-40e0-ae41-26e3f4a5e1c6)

Same screen with 80x24 text mode.

![cc_new1_text](https://github.com/yast/system-role-common-criteria/assets/3638289/f35626f5-6bb2-4ce9-a3e3-1d8eebf3c3d2)

The help text.

![cc_new1_help](https://github.com/yast/system-role-common-criteria/assets/3638289/d1bd1b02-8e1f-43a6-bca7-ac9ee67eb6f5)

## Related pull requests

For the storage proposal to really honor the encryption password set by the role, https://github.com/yast/yast-storage-ng/pull/1344 is also requested.

## Testing

Tested manually together with https://github.com/yast/yast-storage-ng/pull/1344

## More screenshots

![feo_match](https://github.com/yast/system-role-common-criteria/assets/3638289/1624fb47-a10e-480a-98f9-34c329c65f3e)

![feo_length](https://github.com/yast/system-role-common-criteria/assets/3638289/5ac71feb-1334-418a-93de-ac6aa3ba8b57)

![feo_weak](https://github.com/yast/system-role-common-criteria/assets/3638289/a69b8138-5f86-4854-b388-6910587b2ca1)
